### PR TITLE
Update gitpod button in readme and github actions config

### DIFF
--- a/.github/workflows/cb-service-container.yml
+++ b/.github/workflows/cb-service-container.yml
@@ -2,6 +2,11 @@ name: Run NPM tests using couchbase service container
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron: "0 11 * * 0"
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quickstart for using Couchbase with Next.js
 
 
-[![Try it now!](https://da-demo-images.s3.amazonaws.com/runItNow_outline.png?couchbase-example=nextjs-quickstart-repo&source=github)](https://gitpod.io/#https://github.com/couchbase-examples/tutorial-nextjs)
+[![Try it now!](https://da-demo-images.s3.amazonaws.com/runItNow_outline.png?couchbase-example=nextjs-quickstart-repo&source=github)](https://gitpod.io/#https://github.com/couchbase-examples/nextjs-quickstart)
 
 This is a companion repository to the tutorial: "[Quickstart for using Couchbase with Next.js](https://developer.couchbase.com/tutorial-quickstart-nextjs/)" at [developer.couchbase.com](https://developer.couchbase.com), which aims to get you up and running with Couchbase on [NextJS](https://nextjs.org/), connect to a Couchbase cluster, create, read, update, and delete documents, and how to write simple parameterized N1QL queries. It also covers creating a basic front-end using Next.js.
 


### PR DESCRIPTION
- gitpod button now links to correct repo (although previous link forwarded properly too)
- slight update to github workflow