### PR TITLE
TLS Fix

### DIFF
--- a/util/couchbase.js
+++ b/util/couchbase.js
@@ -42,6 +42,11 @@ async function createCouchbaseCluster() {
   try {
     let connectionString = CB_CONNECT_STRING;
 
+    // temporary fix to ensure testability across all environments
+    if (CB_CONNECT_STRING.startsWith('couchbases')) {
+      connectionString = connectionString + '?tls_verify=none';
+    }
+
     cached.conn = await couchbase.connect(connectionString, {
       username: CB_USERNAME,
       password: CB_PASSWORD,


### PR DESCRIPTION
We need to temporarily skip TLS verification to ensure everything can be tested in all envs.