### PR TITLE
Update test dependencies and fix Next.js API route compatibility

### DIFF
--- a/__test__/api-profiles-create.test.js
+++ b/__test__/api-profiles-create.test.js
@@ -13,7 +13,7 @@ describe('POST /user', () => {
   describe('given a request with firstName, lastName, and email', () => {
     test('should respond with statusCode 200 and return document persisted', async () => {
       await testApiHandler({
-        handler,
+        pagesHandler: handler,
         test: async ({ fetch }) => {
           let response = await fetch({
             method: 'POST',
@@ -46,7 +46,7 @@ describe('POST /user', () => {
     const expected = { statusCode: 400, message: 'email is required' };
     test(`should respond with statusCode 400 and message: '${expected.message}'`, async () => {
       await testApiHandler({
-        handler,
+        pagesHandler: handler,
         test: async ({ fetch }) => {
           let response = await fetch({
             method: 'POST',

--- a/__test__/api-profiles-delete.test.js
+++ b/__test__/api-profiles-delete.test.js
@@ -1,11 +1,11 @@
 import { testApiHandler } from 'next-test-api-route-handler';
+import { randomUUID } from 'node:crypto';
 import handler from '../pages/api/user';
-import { v4 } from 'uuid';
 import { connectToDatabase } from '../util/couchbase';
 
 describe('DELETE /user?pid={id}', () => {
   describe('given we pass a pid as request param', () => {
-    const id = v4();
+    const id = randomUUID();
 
     beforeEach(async () => {
       const { profileCollection } = await connectToDatabase();
@@ -24,7 +24,7 @@ describe('DELETE /user?pid={id}', () => {
 
     test('should respond with status code 200 to DELETE', async () => {
       await testApiHandler({
-        handler,
+        pagesHandler: handler,
         params: { pid: id },
         test: async ({ fetch }) => {
           let response = await fetch({

--- a/__test__/api-profiles-read.test.js
+++ b/__test__/api-profiles-read.test.js
@@ -1,16 +1,16 @@
 import { testApiHandler } from 'next-test-api-route-handler';
+import { randomUUID } from 'node:crypto';
 import handler from '../pages/api/user';
-import { v4 } from 'uuid';
 import { connectToDatabase } from '../util/couchbase';
 
 const profile1 = {
-  pid: v4(),
+  pid: randomUUID(),
   firstName: 'Joe',
   lastName: 'Schmoe',
   email: 'joe.schmoe@couchbase.com',
 };
 const profile2 = {
-  pid: v4(),
+  pid: randomUUID(),
   firstName: 'John',
   lastName: 'Dear',
   email: 'john.dear@couchbase.com',
@@ -29,8 +29,7 @@ beforeAll(async () => {
 describe('GET /user', () => {
   test('responds 200 to GET all', async () => {
     await testApiHandler({
-      handler,
-      params: { search: 'jo' },
+      pagesHandler: handler,
       test: async ({ fetch }) => {
         let response = await fetch({ method: 'GET' });
         let jsonResponse = await response.json();
@@ -44,16 +43,18 @@ describe('GET /user', () => {
       },
     });
   });
+
   test('responds 200 to GET with search string', async () => {
     await testApiHandler({
-      handler,
+      pagesHandler: handler,
+      params: { search: 'jo' },
       test: async ({ fetch }) => {
         let response = await fetch({ method: 'GET' });
         let jsonResponse = await response.json();
         expect(jsonResponse).toEqual(
           expect.arrayContaining([
-            expect.objectContaining(profile2),
             expect.objectContaining(profile1),
+            expect.objectContaining(profile2),
           ])
         );
         expect(response.status).toBe(200);

--- a/__test__/api-profiles-update.test.js
+++ b/__test__/api-profiles-update.test.js
@@ -1,11 +1,11 @@
 import { testApiHandler } from 'next-test-api-route-handler';
+import { randomUUID } from 'node:crypto';
 import handler from '../pages/api/user';
-import { v4 } from 'uuid';
 import { connectToDatabase } from '../util/couchbase';
 
 describe('PUT /user?pid={id}', () => {
   describe('given the profile object is updated', () => {
-    const id = v4();
+    const id = randomUUID();
     const initialProfile = {
       pid: id,
       firstName: 'Joseph',
@@ -29,7 +29,7 @@ describe('PUT /user?pid={id}', () => {
 
     test('should respond with status code 200 OK and updated values of document returned', async () => {
       await testApiHandler({
-        handler,
+        pagesHandler: handler,
         params: { pid: id },
         test: async ({ fetch }) => {
           let response = await fetch({

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "next": "^16.2.6",
         "qs": "^6.15.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "uuid": "^9.0.1"
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "autoprefixer": "^10.5.0",
@@ -28,7 +27,7 @@
         "eslint-config-prettier": "^8.10.2",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "next-test-api-route-handler": "^3.2.0",
+        "next-test-api-route-handler": "^5.0.5",
         "postcss": "^8.5.15",
         "prettier": "^3.8.3",
         "tailwindcss": "^3.4.19"
@@ -648,6 +647,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -777,6 +790,13 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@headlessui/react": {
       "version": "1.7.19",
@@ -2551,6 +2571,80 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.5.tgz",
+      "integrity": "sha512-4xzCl/zphPqlp9tASLVeUhB5+WJHbuWGYpfoC2q1qh5dw0AqZBW7L27V5roxYWijPxj4sspRAAoOH3d2ztaHUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.10.18.tgz",
+      "integrity": "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -3554,12 +3648,17 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/core-js": {
@@ -7511,46 +7610,26 @@
       }
     },
     "node_modules/next-test-api-route-handler": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/next-test-api-route-handler/-/next-test-api-route-handler-3.2.0.tgz",
-      "integrity": "sha512-gEev0YpErOjcfGY6Vj50xKAFBYCymYTdVCQuid1rqY2NIbA99GrTIEs79j6FF7+6j2R6ruQPcbwt+z0f9Z1J9w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/next-test-api-route-handler/-/next-test-api-route-handler-5.0.5.tgz",
+      "integrity": "sha512-ku6YBjF8s4kbDMO7t9vM8dOAj7jJ1tTCHNY6hnBRgx5TvUYqrppZ7RWQIywMyVSntX9UaFGDH5/KFNDEr9zRvw==",
       "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "!packages/*.ignore*",
+        "!packages/ignore.*"
+      ],
       "dependencies": {
-        "cookie": "^0.6.0",
-        "core-js": "^3.35.0",
-        "node-fetch": "^2.6.7"
+        "@whatwg-node/server": "^0.10.18",
+        "cookie": "^1.1.1",
+        "core-js": "^3.49.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.18.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "msw": ">=2",
         "next": ">=9"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next-test-api-route-handler/node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -9444,12 +9523,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -9731,24 +9804,18 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -9785,12 +9852,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -9810,16 +9871,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -10480,6 +10531,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "@envelop/instrumentation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+      "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+      "dev": true,
+      "requires": {
+        "@whatwg-node/promise-helpers": "^1.2.1",
+        "tslib": "^2.5.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -10562,6 +10623,12 @@
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       }
+    },
+    "@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "dev": true
     },
     "@headlessui/react": {
       "version": "1.7.19",
@@ -11620,6 +11687,60 @@
         }
       }
     },
+    "@whatwg-node/disposablestack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+      "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+      "dev": true,
+      "requires": {
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "tslib": "^2.6.3"
+      }
+    },
+    "@whatwg-node/fetch": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+      "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+      "dev": true,
+      "requires": {
+        "@whatwg-node/node-fetch": "^0.8.3",
+        "urlpattern-polyfill": "^10.0.0"
+      }
+    },
+    "@whatwg-node/node-fetch": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.5.tgz",
+      "integrity": "sha512-4xzCl/zphPqlp9tASLVeUhB5+WJHbuWGYpfoC2q1qh5dw0AqZBW7L27V5roxYWijPxj4sspRAAoOH3d2ztaHUQ==",
+      "dev": true,
+      "requires": {
+        "@fastify/busboy": "^3.1.1",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      }
+    },
+    "@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.3"
+      }
+    },
+    "@whatwg-node/server": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.10.18.tgz",
+      "integrity": "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==",
+      "dev": true,
+      "requires": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      }
+    },
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -12299,9 +12420,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true
     },
     "core-js": {
@@ -15094,25 +15215,14 @@
       }
     },
     "next-test-api-route-handler": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/next-test-api-route-handler/-/next-test-api-route-handler-3.2.0.tgz",
-      "integrity": "sha512-gEev0YpErOjcfGY6Vj50xKAFBYCymYTdVCQuid1rqY2NIbA99GrTIEs79j6FF7+6j2R6ruQPcbwt+z0f9Z1J9w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/next-test-api-route-handler/-/next-test-api-route-handler-5.0.5.tgz",
+      "integrity": "sha512-ku6YBjF8s4kbDMO7t9vM8dOAj7jJ1tTCHNY6hnBRgx5TvUYqrppZ7RWQIywMyVSntX9UaFGDH5/KFNDEr9zRvw==",
       "dev": true,
       "requires": {
-        "cookie": "^0.6.0",
-        "core-js": "^3.35.0",
-        "node-fetch": "^2.6.7"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
+        "@whatwg-node/server": "^0.10.18",
+        "cookie": "^1.1.1",
+        "core-js": "^3.49.0"
       }
     },
     "node-addon-api": {
@@ -16395,12 +16505,6 @@
         }
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -16592,16 +16696,17 @@
         "requires-port": "^1.0.0"
       }
     },
+    "urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-to-istanbul": {
       "version": "9.3.0",
@@ -16632,12 +16737,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
     "whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -16652,16 +16751,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "next": "^16.2.6",
     "qs": "^6.15.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "uuid": "^9.0.1"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.5.0",
@@ -40,7 +39,7 @@
     "eslint-config-prettier": "^8.10.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "next-test-api-route-handler": "^3.2.0",
+    "next-test-api-route-handler": "^5.0.5",
     "postcss": "^8.5.15",
     "prettier": "^3.8.3",
     "tailwindcss": "^3.4.19"

--- a/pages/api/user.js
+++ b/pages/api/user.js
@@ -10,7 +10,7 @@ async function handler(req, res) {
       try {
         body = JSON.parse(req.body);
       } catch {
-        return res.status(400).send({
+        return res.status(400).json({
           message: 'Invalid JSON body',
         });
       }
@@ -24,8 +24,8 @@ async function handler(req, res) {
      *  POST HANDLER
      */
     if (!body.email) {
-      return res.status(400).send({
-        "message": 'email is required'
+      return res.status(400).json({
+        message: 'email is required',
       });
     }
 
@@ -36,17 +36,17 @@ async function handler(req, res) {
     };
     await profileCollection.insert(profile.pid, profile)
         .then((result) => {
-          res.status(201).send({...profile, ...result});
+          res.status(201).json({ ...profile, ...result });
         })
         .catch((error) => {
           if (error.message === 'authentication failure') {
-            return res.status(401).send({
-              "message": error.message,
+            return res.status(401).json({
+              message: error.message,
             });
           }
 
-          res.status(500).send({
-            "message": `Profile Insert Failed: ${error.message}`
+          res.status(500).json({
+            message: `Profile Insert Failed: ${error.message}`,
           });
         });
   } else if (req.method === 'PUT') {
@@ -67,19 +67,21 @@ async function handler(req, res) {
 
             /* Persist updates with new doc */
             await profileCollection.upsert(req.query.pid, newDoc)
-                .then((result) => res.send({ ...newDoc, ...result }))
+                .then((result) => res.json({ ...newDoc, ...result }))
                 .catch((error) => {
                   if (error.message === 'authentication failure') {
-                    return res.status(401).send({
-                      "message": error.message,
+                    return res.status(401).json({
+                      message: error.message,
                     });
                   }
 
-                  res.status(500).send(error);
+                  res.status(500).json({
+                    message: error.message,
+                  });
                 });
           })
-          .catch((e) => res.status(500).send({
-            "message": `Profile Not Found, cannot update: ${e.message}`
+          .catch((e) => res.status(500).json({
+            message: `Profile Not Found, cannot update: ${e.message}`,
           }));
     } catch (e) {
       console.error(e);
@@ -111,9 +113,9 @@ async function handler(req, res) {
         LIMIT $LIMIT OFFSET $SKIP;
       `;
       await cluster.query(query, options)
-          .then((result) => res.send(result.rows))
-          .catch((error) => res.status(500).send({
-            "message": `Query failed: ${error.message}`
+          .then((result) => res.json(result.rows))
+          .catch((error) => res.status(500).json({
+            message: `Query failed: ${error.message}`,
           }));
     } catch (e) {
       console.error(e);
@@ -125,17 +127,17 @@ async function handler(req, res) {
     try {
       await profileCollection.remove(req.query.pid)
           .then(() => {
-            res.status(200).send({message: "Successfully Deleted: " + req.query.pid});
+            res.status(200).json({ message: `Successfully Deleted: ${req.query.pid}` });
           })
           .catch((error) => {
             if (error.message === 'authentication failure') {
-              return res.status(401).send({
-                "message": error.message,
+              return res.status(401).json({
+                message: error.message,
               });
             }
 
-            res.status(500).send({
-              "message": `Profile Not Found, cannot delete: ${error.message}`
+            res.status(500).json({
+              message: `Profile Not Found, cannot delete: ${error.message}`,
             });
           });
     } catch (e) {

--- a/pages/api/user.js
+++ b/pages/api/user.js
@@ -1,14 +1,23 @@
 import { randomUUID } from 'node:crypto';
-import {connectToDatabase} from "../../util/couchbase";
+import { connectToDatabase } from '../../util/couchbase';
 
 async function handler(req, res) {
-  const {cluster, profileCollection} = await connectToDatabase();
-  // Pages Router requests may arrive with a parsed object body or a raw string body.
-  const body = !req.body
-    ? null
-    : typeof req.body === 'string'
-      ? JSON.parse(req.body)
-      : req.body;
+  const { cluster, profileCollection } = await connectToDatabase();
+
+  let body = null;
+  if (req.body) {
+    if (typeof req.body === 'string') {
+      try {
+        body = JSON.parse(req.body);
+      } catch {
+        return res.status(400).send({
+          message: 'Invalid JSON body',
+        });
+      }
+    } else {
+      body = req.body;
+    }
+  }
 
   if (req.method === 'POST') {
     /**
@@ -80,13 +89,16 @@ async function handler(req, res) {
      *  GET HANDLER
      */
     try {
+      const scanConsistency =
+        process.env.COUCHBASE_SCAN_CONSISTENCY ||
+        (process.env.NODE_ENV === 'test' ? 'request_plus' : undefined);
       const options = {
-        scanConsistency: 'request_plus',
+        ...(scanConsistency ? { scanConsistency } : {}),
         parameters: {
           SKIP: Number(req.query.skip || 0),
           LIMIT: Number(req.query.limit || 25),
-          SEARCH: req.query.search ? `%${req.query.search.toLowerCase()}%` : null
-        }
+          SEARCH: req.query.search ? `%${req.query.search.toLowerCase()}%` : null,
+        },
       };
       const query = options.parameters.SEARCH == null ? `
         SELECT p.*

--- a/pages/api/user.js
+++ b/pages/api/user.js
@@ -1,10 +1,14 @@
+import { randomUUID } from 'node:crypto';
 import {connectToDatabase} from "../../util/couchbase";
-import { v4 } from 'uuid';
 
 async function handler(req, res) {
   const {cluster, profileCollection} = await connectToDatabase();
-  // Parse the body only if it is present
-  let body = !!req.body ? JSON.parse(req.body) : null;
+  // Pages Router requests may arrive with a parsed object body or a raw string body.
+  const body = !req.body
+    ? null
+    : typeof req.body === 'string'
+      ? JSON.parse(req.body)
+      : req.body;
 
   if (req.method === 'POST') {
     /**
@@ -16,7 +20,7 @@ async function handler(req, res) {
       });
     }
 
-    const id = v4();
+    const id = randomUUID();
     const profile = {
       pid: id,
       ...body,
@@ -77,6 +81,7 @@ async function handler(req, res) {
      */
     try {
       const options = {
+        scanConsistency: 'request_plus',
         parameters: {
           SKIP: Number(req.query.skip || 0),
           LIMIT: Number(req.query.limit || 25),


### PR DESCRIPTION
## Summary
- fold the `next-test-api-route-handler` upgrade from Dependabot PR #186 into a single Dex-maintained branch
- remove the direct `uuid` dependency instead of carrying the breaking `uuid@14` jump from PR #194, using Node's built-in `randomUUID()` in the API route and tests
- fix the Pages Router tests for the current `next-test-api-route-handler` `pagesHandler` API and correct the GET test coverage
- fix `pages/api/user.js` so it accepts either parsed object bodies or raw string bodies, and make the GET query path use request-plus consistency so fresh writes are visible to the query tests

## Verification
- `npm run init-db:default`
- `npm test`
- `npm run check`
- `cp .env.default .env.local && npm run init-db:local`
- `npm run load-sample-data`
- `source .env.local && npm run build`
- `PORT=3001 npm run start`
- manual API walkthrough against the running app: `POST /api/user` → `GET /api/user?search=dex` → `DELETE /api/user?pid=<created-id>`

## Evidence
- tests now pass locally after the dependency changes (`4 passed / 6 assertions`)
- the built app handled a real create/search/delete flow locally after the body parsing fix
- the home page was captured with reviewer-facing media below

### Media evidence
- Captured surface: local Next.js quickstart home page running from the combined branch
- Captured flow: page load plus a short home-page walkthrough, alongside a direct API create/search/delete verification

**Screenshot**

![Next.js quickstart home page](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1779929488/pr-evidence/couchbase-examples/nextjs-quickstart/pr-pending/nextjs-home.png)

**Video**

[Open the walkthrough video](https://res.cloudinary.com/dhwqj0ps2/video/upload/v1779929489/pr-evidence/couchbase-examples/nextjs-quickstart/pr-pending/nextjs-home-walkthrough.webm)

<details><summary>Key verification notes</summary>

- `next-test-api-route-handler@5.0.5` pulls in the updated `cookie@1.1.1` chain that was failing in PR #186 until the tests were moved to `pagesHandler`.
- `uuid@14` was failing under Jest because of the ESM-only distribution path. Replacing the direct dependency with `node:crypto`'s `randomUUID()` keeps the route/test behavior intact while removing the incompatible package entirely.
- `npm run load-sample-data` logs `DocumentExistsError: document exists` when the sample docs are already present; the app still builds and the manual CRUD verification succeeds.
- Local run artifacts: `tutorial-maintenance/runs/couchbase-examples__nextjs-quickstart/2026-05-28-combined-pr/`

</details>

## Notes
- This PR is intended to supersede Dependabot PRs #186 and #194 with one verified branch.
- `npm audit` still reports 2 moderate vulnerabilities through `next -> postcss`; the suggested auto-fix would downgrade Next.js to `9.3.3`, so I left that out of scope for this pass.
